### PR TITLE
Publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# WARNING: this information is sensitive; ensure that you treating this file as such
+# this is really only meant for people who are publishing the chrome package
+# (e.g. Nick) but feel free to update these with the relevant credentials if you
+# so choose
+
+KINO_CLIENT_ID="<google oauth app client id>"
+KINO_CLIENT_SECRET="<google oauth app client secret>"
+KINO_REFRESH_TOKEN="<refresh token>" # from https://developer.chrome.com/webstore/using_webstore_api
+KINO_EXTENSION_ID="<chrome web store extension id>"
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 test/extension/failure-screenshots
+.env

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Kino",
   "description": "This extension allows control of websites like youtube.com or egghead.io from the comfort of your text editor",
-  "version": "1.1",
+  "version": "1.2.0",
   "icons" : {
     "128": "kino-logo@3x.png"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,6 +183,16 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
+    "axios": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.2.5",
+        "is-buffer": "1.1.5"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -575,6 +585,12 @@
         "esutils": "2.0.2",
         "isarray": "1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1069,6 +1085,15 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -1364,6 +1389,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
     "is-callable": {
@@ -2434,6 +2465,15 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2443,15 +2483,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "standard",
     "test:integration": "wdio",
-    "package": "zip -r kino.zip extension"
+    "extension:update": "zip -r kino.zip extension && node script/chrome-webstore update",
+    "extension:publish": "node script/chrome-webstore publish"
   },
   "keywords": [],
   "author": "Nick Tomlin <nick.tomlin@gmail.com>",
@@ -33,6 +34,8 @@
     ]
   },
   "devDependencies": {
+    "axios": "^0.16.2",
+    "dotenv": "^4.0.0",
     "standard": "^10.0.3",
     "wdio-chromedriver-service": "^0.1.1",
     "wdio-mocha-framework": "^0.5.11",

--- a/script/chrome-webstore
+++ b/script/chrome-webstore
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const dotenv = require('dotenv')
+const axios = require('axios')
+const querystring = require('querystring')
+const { promisify } = require('util')
+dotenv.load()
+
+const {
+  KINO_CLIENT_ID,
+  KINO_CLIENT_SECRET,
+  KINO_EXTENSION_ID,
+  KINO_REFRESH_TOKEN
+} = process.env
+
+const publishUrl = `https://www.googleapis.com/chromewebstore/v1.1/items/${KINO_EXTENSION_ID}/publish`
+const updateUrl = `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${KINO_EXTENSION_ID}`
+const readFile = promisify(fs.readFile)
+
+function getHeaders (accessToken, overrides = {}) {
+  return Object.assign({}, {
+    Authorization: `Bearer ${accessToken}`
+  }, overrides)
+}
+
+function logErrors (e) {
+  if (e.response && e.response.data.error) {
+    console.log('error:', JSON.stringify(e.response.data.error))
+  }
+}
+
+function getAccessToken () {
+  const url = 'https://accounts.google.com/o/oauth2/token'
+
+  return axios.post(url, querystring.stringify({
+    client_id: KINO_CLIENT_ID,
+    client_secret: KINO_CLIENT_SECRET,
+    grant_type: 'refresh_token',
+    refresh_token: KINO_REFRESH_TOKEN
+  }), {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
+  }).then(res => res.data.access_token)
+}
+
+async function updateExtension (accessToken, zipBlob) {
+  const headers = getHeaders(accessToken)
+  return axios.put(updateUrl, zipBlob, { headers })
+}
+
+async function publishExtension (accessToken, trusted) {
+  const headers = getHeaders(accessToken)
+  const suffix = trusted ? '?publishTarget=trustedTesters' : ''
+  return axios.post(`${publishUrl}${suffix}`, {}, { headers })
+}
+
+async function update (zipPath) {
+  try {
+    const accessToken = await getAccessToken()
+    const zipBlob = await readFile(zipPath)
+    const response = await updateExtension(accessToken, zipBlob)
+    console.log('Done updating', response.data)
+
+    if (response.data.itemError) {
+      let e = new Error(`Error Updating: ${JSON.stringify(response.data)}`)
+      e.response = { data: { error: response.data.itemError } }
+      throw e
+    }
+  } catch (e) {
+    console.error('There was an error updating extension')
+    logErrors(e)
+    throw e
+  }
+}
+
+async function publish (trusted) {
+  try {
+    const accessToken = await getAccessToken()
+    const response = await publishExtension(accessToken, trusted)
+    console.log('Done publishing', response.data)
+  } catch (e) {
+    console.log('Error publishing', e)
+    logErrors(e)
+    throw e
+  }
+}
+
+const command = process.argv[2]
+
+switch (command) {
+  case 'update':
+    const zipPath = process.argv[3] || 'kino.zip'
+    update(zipPath)
+    break
+
+  case 'publish':
+    publish(process.argv[3])
+    break
+
+  default:
+    console.log(`chrome-webstore - helper for interacting with the chrome webstore api
+      update <zip file path: optional> - Update an extension (update is saved as a draft)
+      publish <'trusted': optional> - Publish an updated extension draft. Optionally publish to truestedTesters by specifying 'trusted'
+    `)
+}


### PR DESCRIPTION
This bumps the manifest version and adds a script to automate updating and publishing. The API is OAuth driven so we'll need to store the oauth client/secret and refresh token to do this. 

In the future we can perhaps automate this from a travis run using something like semantic release.