### PR TITLE
fix: Ensure action gets sent to currently focused tab (and not console or another window)

### DIFF
--- a/extension/event.js
+++ b/extension/event.js
@@ -1,9 +1,15 @@
 /* global Storage */
 const port = chrome.runtime.connectNative('com.nicktomlin.kino')
 
+const tabQuery = {
+  active: true,
+  windowType: chrome.tabs.WindowType.NORMAL,
+  lastFocusedWindow: true
+}
+
 function pageAction (action, message) {
-  chrome.tabs.query({active: true}, async (tabs) => {
-    if (!tabs.length) { console.info('No tabs found; you may have another window (like an inspector) on top of the video tab'); return }
+  chrome.tabs.query(tabQuery, async (tabs) => {
+    if (!tabs.length) { console.info('No tabs found; you may be using a non active window'); return }
     if (chrome.runtime.lastError) {
       console.log('Error querying tabs', tabs, chrome.runtime.lastError.message)
     }
@@ -13,6 +19,7 @@ function pageAction (action, message) {
 
     const code = (mappings[hostname] && mappings[hostname][action]) || mappings[Storage.ALL_HOSTS][action]
     if (code) {
+      console.info(`Dispatching to ${hostname} with ${code}`)
       chrome.tabs.executeScript(tabs[0].id, { code })
     }
   })
@@ -23,7 +30,9 @@ port.onMessage.addListener((rawMessage) => {
   try { message = JSON.parse(rawMessage) } catch (e) {}
   console.info('Received native message', message)
 
-  if (message.action) { pageAction(message.action, message) }
+  if (message.action) {
+    pageAction(message.action, message)
+  }
 })
 
 port.onDisconnect.addListener(() => {


### PR DESCRIPTION
We could previously send an action to the first open tab of any type. This mean that if you opened two windows, `tabs[0]` would be the active tab of the first window and not the second (and now active) window.

Specifying `windowType: chrome.tabs.WindowType.NORMAL` means that we exclude the devtools pane (since that is a valid target otherwise).